### PR TITLE
Removed container_name from docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,12 @@
 version: "3.7"
 services:
   spamassassin:
-    container_name: eml_analyzer_spamassassin
     image: instantlinux/spamassassin:3.4.6-1
     ports:
       - ${PORT_SPAMASSASSIN:-783}:783
     restart: always
 
-  eml_analyzer:
-    container_name: eml_analyzer_app
+  eml_analyzer:    
     build:
       context: ./
       dockerfile: app.Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - ${PORT_SPAMASSASSIN:-783}:783
     restart: always
 
-  eml_analyzer:    
+  eml_analyzer:
     build:
       context: ./
       dockerfile: app.Dockerfile


### PR DESCRIPTION
Container name is not necessary, as docker-compose uses the service name if no container_name is specified. This allows to run multiple instances of eml_analyzer (e.g. dev and prod) on the same docker host.