### PR TITLE
Add optional Redis analysis caching

### DIFF
--- a/backend/api/api.py
+++ b/backend/api/api.py
@@ -1,7 +1,8 @@
 from fastapi import APIRouter
 
-from backend.api.endpoints import analyze, submit
+from backend.api.endpoints import analyze, submit, lookup
 
 api_router = APIRouter()
 api_router.include_router(analyze.router, prefix="/analyze", tags=["analyze"])
 api_router.include_router(submit.router, prefix="/submit", tags=["submit"])
+api_router.include_router(lookup.router, prefix="/lookup", tags=["lookup"])

--- a/backend/api/endpoints/analyze.py
+++ b/backend/api/endpoints/analyze.py
@@ -6,7 +6,7 @@ from pydantic import ValidationError
 from backend.factories.response import ResponseFactory
 from backend.schemas.payload import FilePayload, Payload
 from backend.schemas.response import Response
-import backend.core.settings
+from backend.core.settings import REDIS_HOST, REDIS_PASSWORD, REDIS_EXPIRE
 
 router = APIRouter()
 
@@ -22,9 +22,12 @@ async def _analyze(file: bytes) -> Response:
 
     data = await ResponseFactory.from_bytes(payload.file)
 
-    if backend.core.settings.REDIS_HOST:
-        redis_conn = StrictRedis(host=backend.core.settings.REDIS_HOST, password=backend.core.settings.REDIS_PASSWORD)
+    if REDIS_HOST:
+        redis_conn = StrictRedis(host=REDIS_HOST, password=REDIS_PASSWORD)
         redis_conn.hset("results", data.identifier, data.json())
+
+        if REDIS_EXPIRE != -1:
+            redis_conn.expire(name=data.identifier, time=REDIS_EXPIRE)
 
     return data
 

--- a/backend/api/endpoints/analyze.py
+++ b/backend/api/endpoints/analyze.py
@@ -1,3 +1,4 @@
+from redis import StrictRedis
 from fastapi import APIRouter, File, HTTPException, status
 from fastapi.encoders import jsonable_encoder
 from pydantic import ValidationError
@@ -5,6 +6,7 @@ from pydantic import ValidationError
 from backend.factories.response import ResponseFactory
 from backend.schemas.payload import FilePayload, Payload
 from backend.schemas.response import Response
+import backend.core.settings
 
 router = APIRouter()
 
@@ -18,7 +20,13 @@ async def _analyze(file: bytes) -> Response:
             detail=jsonable_encoder(exc.errors()),
         ) from exc
 
-    return await ResponseFactory.from_bytes(payload.file)
+    data = await ResponseFactory.from_bytes(payload.file)
+
+    if backend.core.settings.REDIS_HOST:
+        redis_conn = StrictRedis(host=backend.core.settings.REDIS_HOST, password=backend.core.settings.REDIS_PASSWORD)
+        redis_conn.hset("results", data.identifier, data.json())
+
+    return data
 
 
 @router.post(

--- a/backend/api/endpoints/analyze.py
+++ b/backend/api/endpoints/analyze.py
@@ -24,7 +24,7 @@ async def _analyze(file: bytes) -> Response:
 
     if REDIS_HOST:
         redis_conn = StrictRedis(host=REDIS_HOST, password=REDIS_PASSWORD)
-        redis_conn.hset("results", data.identifier, data.json())
+        redis_conn.hset(data.identifier, "analysis", data.json())
 
         if REDIS_EXPIRE != -1:
             redis_conn.expire(name=data.identifier, time=REDIS_EXPIRE)

--- a/backend/api/endpoints/lookup.py
+++ b/backend/api/endpoints/lookup.py
@@ -23,7 +23,7 @@ async def lookup(identifier: str) -> Response:
         )
 
     redis_conn = StrictRedis(host=REDIS_HOST, password=REDIS_PASSWORD)
-    data = redis_conn.hget("results", identifier)
+    data = redis_conn.hget(identifier, "analysis")
     if not data:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/api/endpoints/lookup.py
+++ b/backend/api/endpoints/lookup.py
@@ -1,7 +1,7 @@
 import json
 
 from redis import StrictRedis
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, status
 
 from backend.schemas.response import Response
 from backend.core.settings import REDIS_HOST, REDIS_PASSWORD
@@ -17,11 +17,17 @@ router = APIRouter()
 )
 async def lookup(identifier: str) -> Response:
     if not REDIS_HOST:
-        raise HTTPException(502)
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail="Redis cache is not enabled",
+        )
 
     redis_conn = StrictRedis(host=REDIS_HOST, password=REDIS_PASSWORD)
     data = redis_conn.hget("results", identifier)
     if not data:
-        raise HTTPException(404)
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Analysis cache not found",
+        )
 
     return json.loads(data)

--- a/backend/api/endpoints/lookup.py
+++ b/backend/api/endpoints/lookup.py
@@ -4,7 +4,7 @@ from redis import StrictRedis
 from fastapi import APIRouter, HTTPException
 
 from backend.schemas.response import Response
-import backend.core.settings
+from backend.core.settings import REDIS_HOST, REDIS_PASSWORD
 
 router = APIRouter()
 
@@ -16,10 +16,10 @@ router = APIRouter()
     status_code=200,
 )
 async def lookup(identifier: str) -> Response:
-    if not backend.core.settings.REDIS_HOST:
+    if not REDIS_HOST:
         raise HTTPException(502)
 
-    redis_conn = StrictRedis(host=backend.core.settings.REDIS_HOST, password=backend.core.settings.REDIS_PASSWORD)
+    redis_conn = StrictRedis(host=REDIS_HOST, password=REDIS_PASSWORD)
     data = redis_conn.hget("results", identifier)
     if not data:
         raise HTTPException(404)

--- a/backend/api/endpoints/lookup.py
+++ b/backend/api/endpoints/lookup.py
@@ -1,0 +1,27 @@
+import json
+
+from redis import StrictRedis
+from fastapi import APIRouter, HTTPException
+
+from backend.schemas.response import Response
+import backend.core.settings
+
+router = APIRouter()
+
+@router.get(
+    "/{identifier}/",
+    response_description="Return an analysis result",
+    summary="Lookup cached analysis",
+    description="Try to fetch existing analysis from database",
+    status_code=200,
+)
+async def lookup(identifier: str) -> Response:
+    if not backend.core.settings.REDIS_HOST:
+        raise HTTPException(502)
+
+    redis_conn = StrictRedis(host=backend.core.settings.REDIS_HOST, password=backend.core.settings.REDIS_PASSWORD)
+    data = redis_conn.hget("results", identifier)
+    if not data:
+        raise HTTPException(404)
+
+    return json.loads(data)

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -23,3 +23,6 @@ URLSCAN_API_KEY: Secret = config("URLSCAN_API_KEY", cast=Secret, default="")
 VIRUSTOTAL_API_KEY: Secret = config("VIRUSTOTAL_API_KEY", cast=Secret, default="")
 
 INQUEST_API_KEY: Secret = config("INQUEST_API_KEY", cast=Secret, default="")
+
+REDIS_HOST : str = config("REDIS_HOST", cast=str, default="redis")
+REDIS_PASSWORD: str = config("REDIS_PASSWORD", cast=str, default="changeme")

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -26,3 +26,4 @@ INQUEST_API_KEY: Secret = config("INQUEST_API_KEY", cast=Secret, default="")
 
 REDIS_HOST : str = config("REDIS_HOST", cast=str, default="redis")
 REDIS_PASSWORD: str = config("REDIS_PASSWORD", cast=str, default="changeme")
+REDIS_EXPIRE: str = config("REDIS_EXPIRE", cast=int, default=3600)

--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -24,6 +24,6 @@ VIRUSTOTAL_API_KEY: Secret = config("VIRUSTOTAL_API_KEY", cast=Secret, default="
 
 INQUEST_API_KEY: Secret = config("INQUEST_API_KEY", cast=Secret, default="")
 
-REDIS_HOST : str = config("REDIS_HOST", cast=str, default="redis")
+REDIS_HOST : str = config("REDIS_HOST", cast=str, default="")
 REDIS_PASSWORD: str = config("REDIS_PASSWORD", cast=str, default="changeme")
 REDIS_EXPIRE: str = config("REDIS_EXPIRE", cast=int, default=3600)

--- a/backend/factories/eml.py
+++ b/backend/factories/eml.py
@@ -1,5 +1,6 @@
 from io import BytesIO
 from typing import Any
+from hashlib import sha256
 
 import arrow
 import dateparser
@@ -37,6 +38,7 @@ class EmlFactory:
         self.eml_file = eml_file
         parser = EmlParser(include_raw_body=True, include_attachment_data=True)
         self.parsed = parser.decode_email_bytes(eml_file)
+        self.parsed["identifier"] = sha256(eml_file).hexdigest()
 
     def _normalize_received_date(self, received: dict):
         date = received.get("date", "")

--- a/backend/factories/response.py
+++ b/backend/factories/response.py
@@ -59,7 +59,7 @@ class ResponseFactory:
         verdicts.append(OleIDVerdictFactory.from_attachments(eml.attachments))
         # Add VT verdict
 
-        return Response(eml=eml, verdicts=verdicts)
+        return Response(eml=eml, verdicts=verdicts, identifier=eml.identifier)
 
     @classmethod
     async def from_bytes(cls, eml_file: bytes) -> Response:

--- a/backend/schemas/eml.py
+++ b/backend/schemas/eml.py
@@ -65,3 +65,4 @@ class Eml(APIModel):
     attachments: list[Attachment]
     bodies: list[Body]
     header: Header
+    identifier: str

--- a/backend/schemas/response.py
+++ b/backend/schemas/response.py
@@ -7,3 +7,4 @@ from .api_model import APIModel
 class Response(APIModel):
     eml: Eml
     verdicts: list[Verdict]
+    identifier: str

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,3 +21,8 @@ services:
     restart: always
     depends_on:
       - spamassassin
+  redis:
+    image: library/redis
+    command: /bin/sh -c "redis-server --requirepass ${REDIS_PASSWORD:-changeme}"
+    ports:
+      - 6379:6379

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - INQUEST_API_KEY=${INQUEST_API_KEY}
       - SPAMASSASSIN_HOST=spamassassin
       - SPAMASSASSIN_PORT=${SPAMASSASSIN_PORT:-783}
+      - REDIS_HOST=redis
     restart: always
     depends_on:
       - spamassassin

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -17,5 +17,9 @@ export const API = {
       }
     })
     return res.data
+  },
+  async lookupFile(identifier: string) : Promise<Response> {
+    const res = await client.get<Response>(`/api/lookup/${identifier}/`);
+    return res.data
   }
 }

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -74,7 +74,7 @@ export default defineComponent({
       })
 
       try {
-        await analyzeFileTask.perform(null, fileIdentifier)
+        await analyzeFileTask.perform({"identifier": fileIdentifier })
         loadingComponent.close()
       } catch (error) {
         loadingComponent.close()
@@ -91,7 +91,7 @@ export default defineComponent({
       })
 
       try {
-        await analyzeFileTask.perform(emlFile.value, null)
+        await analyzeFileTask.perform({"file": emlFile.value })
         loadingComponent.close()
       } catch (error) {
         loadingComponent.close()

--- a/frontend/src/views/Home.vue
+++ b/frontend/src/views/Home.vue
@@ -74,7 +74,7 @@ export default defineComponent({
       })
 
       try {
-        await analyzeFileTask.perform({"identifier": fileIdentifier })
+        await analyzeFileTask.perform(null, fileIdentifier)
         loadingComponent.close()
       } catch (error) {
         loadingComponent.close()
@@ -91,7 +91,7 @@ export default defineComponent({
       })
 
       try {
-        await analyzeFileTask.perform({"file": emlFile.value })
+        await analyzeFileTask.perform(emlFile.value, null)
         loadingComponent.close()
       } catch (error) {
         loadingComponent.close()

--- a/poetry.lock
+++ b/poetry.lock
@@ -2072,6 +2072,7 @@ files = [
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:69b023b2b4daa7548bcfbd4aa3da05b3a74b772db9e23b982788168117739938"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e0b275a9ecc9c0c0c07b4b90ba548307583c125f54d5b6946cfee6360c733d"},
     {file = "PyYAML-6.0.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba336e390cd8e4d1739f42dfe9bb83a3cc2e80f567d8805e11b46f4a943f5515"},
+    {file = "PyYAML-6.0.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:326c013efe8048858a6d312ddd31d56e468118ad4cdeda36c719bf5bb6192290"},
     {file = "PyYAML-6.0.1-cp310-cp310-win32.whl", hash = "sha256:bd4af7373a854424dabd882decdc5579653d7868b8fb26dc7d0e99f823aa5924"},
     {file = "PyYAML-6.0.1-cp310-cp310-win_amd64.whl", hash = "sha256:fd1592b3fdf65fff2ad0004b5e363300ef59ced41c2e6b3a99d4089fa8c5435d"},
     {file = "PyYAML-6.0.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6965a7bc3cf88e5a1c3bd2e0b5c22f8d677dc88a455344035f03399034eb3007"},
@@ -2079,8 +2080,16 @@ files = [
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42f8152b8dbc4fe7d96729ec2b99c7097d656dc1213a3229ca5383f973a5ed6d"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:062582fca9fabdd2c8b54a3ef1c978d786e0f6b3a1510e0ac93ef59e0ddae2bc"},
     {file = "PyYAML-6.0.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d2b04aac4d386b172d5b9692e2d2da8de7bfb6c387fa4f801fbf6fb2e6ba4673"},
+    {file = "PyYAML-6.0.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:e7d73685e87afe9f3b36c799222440d6cf362062f78be1013661b00c5c6f678b"},
     {file = "PyYAML-6.0.1-cp311-cp311-win32.whl", hash = "sha256:1635fd110e8d85d55237ab316b5b011de701ea0f29d07611174a1b42f1444741"},
     {file = "PyYAML-6.0.1-cp311-cp311-win_amd64.whl", hash = "sha256:bf07ee2fef7014951eeb99f56f39c9bb4af143d8aa3c21b1677805985307da34"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:855fb52b0dc35af121542a76b9a84f8d1cd886ea97c84703eaa6d88e37a2ad28"},
+    {file = "PyYAML-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40df9b996c2b73138957fe23a16a4f0ba614f4c0efce1e9406a184b6d07fa3a9"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a08c6f0fe150303c1c6b71ebcd7213c2858041a7e01975da3a99aed1e7a378ef"},
+    {file = "PyYAML-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6c22bec3fbe2524cde73d7ada88f6566758a8f7227bfbf93a408a9d86bcc12a0"},
+    {file = "PyYAML-6.0.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:8d4e9c88387b0f5c7d5f281e55304de64cf7f9c0021a3525bd3b1c542da3b0e4"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win32.whl", hash = "sha256:d483d2cdf104e7c9fa60c544d92981f12ad66a457afae824d146093b8c294c54"},
+    {file = "PyYAML-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0d3304d8c0adc42be59c5f8a4d9e3d7379e6955ad754aa9d6ab7a398b59dd1df"},
     {file = "PyYAML-6.0.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:50550eb667afee136e9a77d6dc71ae76a44df8b3e51e41b77f6de2932bfe0f47"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1fe35611261b29bd1de0070f0b2f47cb6ff71fa6595c077e42bd0c419fa27b98"},
     {file = "PyYAML-6.0.1-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:704219a11b772aea0d8ecd7058d0082713c3562b4e271b849ad7dc4a5c90c13c"},
@@ -2097,6 +2106,7 @@ files = [
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a0cd17c15d3bb3fa06978b4e8958dcdc6e0174ccea823003a106c7d4d7899ac5"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:28c119d996beec18c05208a8bd78cbe4007878c6dd15091efb73a30e90539696"},
     {file = "PyYAML-6.0.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7e07cbde391ba96ab58e532ff4803f79c4129397514e1413a7dc761ccd755735"},
+    {file = "PyYAML-6.0.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:49a183be227561de579b4a36efbb21b3eab9651dd81b1858589f796549873dd6"},
     {file = "PyYAML-6.0.1-cp38-cp38-win32.whl", hash = "sha256:184c5108a2aca3c5b3d3bf9395d50893a7ab82a38004c8f61c258d4428e80206"},
     {file = "PyYAML-6.0.1-cp38-cp38-win_amd64.whl", hash = "sha256:1e2722cc9fbb45d9b87631ac70924c11d3a401b2d7f410cc0e3bbf249f2dca62"},
     {file = "PyYAML-6.0.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:9eb6caa9a297fc2c2fb8862bc5370d0303ddba53ba97e71f08023b6cd73d16a8"},
@@ -2104,6 +2114,7 @@ files = [
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5773183b6446b2c99bb77e77595dd486303b4faab2b086e7b17bc6bef28865f6"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b786eecbdf8499b9ca1d697215862083bd6d2a99965554781d0d8d1ad31e13a0"},
     {file = "PyYAML-6.0.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc1bf2925a1ecd43da378f4db9e4f799775d6367bdb94671027b73b393a7c42c"},
+    {file = "PyYAML-6.0.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:04ac92ad1925b2cff1db0cfebffb6ffc43457495c9b3c39d3fcae417d7125dc5"},
     {file = "PyYAML-6.0.1-cp39-cp39-win32.whl", hash = "sha256:faca3bdcf85b2fc05d06ff3fbc1f83e1391b3e724afa3feba7d13eeab355484c"},
     {file = "PyYAML-6.0.1-cp39-cp39-win_amd64.whl", hash = "sha256:510c9deebc5c0225e8c96813043e62b680ba2f9c50a08d3724c7f28a747d1486"},
     {file = "PyYAML-6.0.1.tar.gz", hash = "sha256:bfdf460b1736c775f2ba9f6a92bca30bc2095067b8a9d77876d1fad6cc3b4a43"},
@@ -2213,6 +2224,24 @@ files = [
 
 [package.dependencies]
 cffi = {version = "*", markers = "implementation_name == \"pypy\""}
+
+[[package]]
+name = "redis"
+version = "5.0.1"
+description = "Python client for Redis database and key-value store"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "redis-5.0.1-py3-none-any.whl", hash = "sha256:ed4802971884ae19d640775ba3b03aa2e7bd5e8fb8dfaed2decce4d0fc48391f"},
+    {file = "redis-5.0.1.tar.gz", hash = "sha256:0dab495cd5753069d3bc650a0dde8a8f9edde16fc5691b689a566eda58100d0f"},
+]
+
+[package.dependencies]
+async-timeout = {version = ">=4.0.2", markers = "python_full_version <= \"3.11.2\""}
+
+[package.extras]
+hiredis = ["hiredis (>=1.0.0)"]
+ocsp = ["cryptography (>=36.0.1)", "pyopenssl (==20.0.1)", "requests (>=2.26.0)"]
 
 [[package]]
 name = "regex"
@@ -2869,4 +2898,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "2c9ab0d4d3bdc0c3816e3022cebe7341bdad1a868de8443464acbbe908d6b1d7"
+content-hash = "449d8a9c65e32aa5c7161cf58c3d9ab5ac25169d1f0c21adac7a20250e515714"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ pydantic = "^2.5"
 pyhumps = "^3.8.0"
 python-magic = "^0.4.27"
 python-multipart = "^0.0"
+redis = "^5.0.0"
 uvicorn = "^0.25"
 vt-py = "^0.18"
 


### PR DESCRIPTION
Hi, we're using eml-analzyer to dissect various eml files and it's working great, thanks!

One issue we have is that files are in various other systems and downloading and uploading them one by one is pretty painful. 

As far as i know, right now there is no possibility of directly uploading a file and displaying it from another origin (mainly due to the single-page-application architecture).

This PR proposes an additional component that saves/caches the result eml analysis and allows users to easily query view and query the database on page on using the anchor link(`#`). An example "analysis link" looks like this: https://eml.service/#2c6077cb96da133a6c100f7149b31a963e7a49553d7c93c1ae0481249e262a8d

Redis is both completely optional and opt-in so it shouldn't cause any problem for existing users. Nevertheless, I completely understand you don't want to merge this but since I've already added this in our instance you might be interested in it as well ^^