### PR TITLE
Synchronize outlookmsgfile fork

### DIFF
--- a/backend/outlookmsgfile.py
+++ b/backend/outlookmsgfile.py
@@ -272,7 +272,7 @@ def parse_properties(  # noqa: C901
         try:
             properties[tag_name] = tag_type.load(value)
         except Exception as e:
-            logger.error(f"Error while reading stream: {str(e)}")
+            logger.error(f"Error while reading stream: {e!s}")
 
     # String8 strings use code page information stored in other
     # properties, which may not be present. Find the Python
@@ -310,9 +310,9 @@ def parse_properties(  # noqa: C901
         try:
             properties[tag_name] = tag_type.load(value, encodings=encodings, doc=doc)
         except KeyError as e:
-            logger.error(f"Error while reading stream: {str(e)} not found")
+            logger.error(f"Error while reading stream: {e!s} not found")
         except Exception as e:
-            logger.error(f"Error while reading stream: {str(e)}")
+            logger.error(f"Error while reading stream: {e!s}")
 
     return properties
 

--- a/backend/outlookmsgfile.py
+++ b/backend/outlookmsgfile.py
@@ -188,7 +188,7 @@ def process_attachment(
         msg.add_attachment(blob, filename=filename)
 
 
-def parse_properties(
+def parse_properties(  # noqa: C901
     properties: CompoundFileEntity,
     is_top_level: bool,
     container: CompoundFileEntity,

--- a/backend/outlookmsgfile.py
+++ b/backend/outlookmsgfile.py
@@ -241,7 +241,7 @@ def parse_properties(  # noqa: C901
                     value = innerstream.read()
             except Exception:
                 # Stream isn't present!
-                logger.error("stream missing {}".format(streamname))
+                logger.error(f"stream missing {streamname}")
                 continue
 
         elif isinstance(tag_type, EMBEDDED_MESSAGE):
@@ -253,12 +253,12 @@ def parse_properties(  # noqa: C901
                 value = container[streamname]
             except Exception:
                 # Stream isn't present!
-                logger.error("stream missing {}".format(streamname))
+                logger.error(f"stream missing {streamname}")
                 continue
 
         else:
             # unrecognized type
-            logger.error("unhandled property type {}".format(hex(property_type)))
+            logger.error(f"unhandled property type {hex(property_type)}")
             continue
 
         raw_properties[tag_name] = (tag_type, value)
@@ -272,7 +272,7 @@ def parse_properties(  # noqa: C901
         try:
             properties[tag_name] = tag_type.load(value)
         except Exception as e:
-            logger.error("Error while reading stream: {}".format(str(e)))
+            logger.error(f"Error while reading stream: {str(e)}")
 
     # String8 strings use code page information stored in other
     # properties, which may not be present. Find the Python
@@ -310,9 +310,9 @@ def parse_properties(  # noqa: C901
         try:
             properties[tag_name] = tag_type.load(value, encodings=encodings, doc=doc)
         except KeyError as e:
-            logger.error("Error while reading stream: {} not found".format(str(e)))
+            logger.error(f"Error while reading stream: {str(e)} not found")
         except Exception as e:
-            logger.error("Error while reading stream: {}".format(str(e)))
+            logger.error(f"Error while reading stream: {str(e)}")
 
     return properties
 

--- a/backend/outlookmsgfile.py
+++ b/backend/outlookmsgfile.py
@@ -397,7 +397,7 @@ class STRING8(VariableLengthValueLoader):
         for encoding in encodings:
             try:
                 return value.decode(encoding=encoding, errors="strict")
-            except UnicodeError:
+            except Exception:
                 # Try the next one.
                 pass
         return value.decode(encoding=FALLBACK_ENCODING, errors="replace")

--- a/backend/outlookmsgfile.py
+++ b/backend/outlookmsgfile.py
@@ -201,7 +201,6 @@ def parse_properties(
     # in the mapping at the top of this module.
 
     # Load stream content.
-    # Load stream content.
     with doc.open(properties) as stream:
         stream = stream.read()
 


### PR DESCRIPTION
I came across an error while processing a msg file that contained non-ascii characters in the recipients' address node (`__substg1.0_0E04001E`).

```
  File "/usr/src/app/backend/services/outlookmsgfile.py", line 40, in to_email
    return load_message_stream(doc.root, True, doc)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/app/backend/services/outlookmsgfile.py", line 47, in load_message_stream
    props = parse_properties(entry["__properties_version1.0"], is_top_level, entry, doc)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/app/backend/services/outlookmsgfile.py", line 243, in parse_properties
    value = tag_type.load(value)
            ^^^^^^^^^^^^^^^^^^^^
  File "/usr/src/app/backend/services/outlookmsgfile.py", line 345, in load
    return value.decode("utf8").rstrip("\x00")
           ^^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xb3 in position 16: invalid start byte
```
Unfortunately, I'm unable to share the original msg file.

I did some reading of `[MS-OXMSG].pdf` and come to the conclusion that if the node contents aren't unicode-encoded (`non-Unicode` encoding) and the specification only mentions ANSI, we cannot really be sure of the original encoding used.

![image (5)](https://github.com/ninoseki/eml_analyzer/assets/2192416/aea5a2da-8742-40a1-b371-3d4865ec4fea)

Current version of the forked library takes care of that by using some heuristics and falling back to `cp1252`: https://github.com/JoshData/convert-outlook-msg-file/blob/primary/outlookmsgfile.py#L391

That seems to make sense so I synchronized portions of the library used to parse the email properties.
It might make more sense to update the whole script to the current version but since it's listed as a "fork" I was not sure if it wouldn't overwrite any changes that you've made.




 