### PR TITLE
Fix parsing error when spam emails sent invalid dates

### DIFF
--- a/backend/schemas/eml.py
+++ b/backend/schemas/eml.py
@@ -36,12 +36,12 @@ class Body(APIModel):
 
 class Received(APIModel):
     by: list[str] | None = None
-    date: datetime
+    date: str = ""
     for_: list[str] | None = Field(default=None, alias="for")
     from_: list[str] | None = Field(default=None, alias="from")
     src: str
     with_: str | None = Field(default=None, alias="with")
-    delay: int
+    delay: int | None = None
 
 
 class Header(APIModel):


### PR DESCRIPTION
While working on blog post, I noticed that some spam campaigns have started adding invalid dates (or outright removing them). This is causing eml_analyzer and several other similar tools to fail at providing a report. 

This PR handles the invalid dates by setting date to an empty str and the application will now indicate "Invalid Date" when such cases are met. 