### PR TITLE
Fix relative paths

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,18 +4,18 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
-    <link rel="icon" href="/favicon.ico" />
+    <link rel="icon" href="./favicon.ico" />
     <title>EML Analyzer</title>
   </head>
   <body>
     <noscript>
-      <strong
-        >We're sorry but EML Analyzer doesn't work properly without JavaScript enabled. Please
-        enable it to continue.</strong
-      >
+      <strong>
+        We're sorry but EML Analyzer doesn't work properly without JavaScript enabled. Please
+        enable it to continue.
+      </strong>
     </noscript>
     <div id="app"></div>
-    <script type="module" src="/src/main.ts"></script>
+    <script type="module" src="./src/main.ts"></script>
     <!-- built files will be auto injected -->
   </body>
 </html>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -8,7 +8,7 @@ export const API = {
   async analyze(file: File): Promise<ResponseType> {
     const formData = new FormData()
     formData.append('file', file)
-    const res = await client.post('/api/analyze/file', formData, {
+    const res = await client.post('./api/analyze/file', formData, {
       headers: {
         'Content-Type': 'multipart/form-data'
       }
@@ -16,15 +16,15 @@ export const API = {
     return ResponseSchema.parse(res.data)
   },
   async lookup(id: string): Promise<ResponseType> {
-    const res = await client.get(`/api/lookup/${id}`)
+    const res = await client.get(`./api/lookup/${id}`)
     return ResponseSchema.parse(res.data)
   },
   async getCacheKeys(): Promise<string[]> {
-    const res = await client.get<string[]>(`/api/cache/`)
+    const res = await client.get<string[]>(`./api/cache/`)
     return res.data
   },
   async getStatus(): Promise<StatusType> {
-    const res = await client.get(`/api/status/`)
+    const res = await client.get(`./api/status/`)
     return StatusSchema.parse(res.data)
   }
 }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,11 +6,17 @@ import { defineConfig } from 'vite'
 const env = process.env
 const target = env.BACKEND_URL || 'http://localhost:8000/'
 
+const basePath = env.VITE_BASE_PATH || '/'
+const apiPath = `${basePath}api`
+
 export default defineConfig({
+  base: basePath,
   plugins: [vue()],
   server: {
+    allowedHosts: true,
+    origin: '',
     proxy: {
-      '/api': target
+      [apiPath]: target
     }
   },
   resolve: {


### PR DESCRIPTION
Changes to allow running eml_analyzer from a sub-path, for instance lab.company.com/eml_analyzer/

Requires setting up a reverse proxy and a matching setting in VITE_BASE_PATH environment variable.