### PR TITLE
Fix upload item styling

### DIFF
--- a/frontend/src/components/UploadItem.vue
+++ b/frontend/src/components/UploadItem.vue
@@ -111,10 +111,10 @@ input[type='file'] {
   opacity: 0;
   outline: none;
   cursor: pointer;
-  z-index: -1;
 }
 
 .upload-draggable {
+  position: relative;
   cursor: pointer;
   padding: 0.25em;
   border: 1px dashed hsl(0, 0%, 71%);


### PR DESCRIPTION
It seems the recent frontend changes might've broken the file upload widget.

`z-index: -1` was causing it to not be clickable and lack of `position: relative` on parnet was causing the file input to fill the entire screen.

I'm not sure if those changes are the best possible solution css-wise but it does work OK after applying them