### PR TITLE
Fix theme switch default value

### DIFF
--- a/frontend/src/components/NavbarItem.vue
+++ b/frontend/src/components/NavbarItem.vue
@@ -11,7 +11,7 @@ const status = computed(() => {
 
 const toggleTheme = () => {
   const currentTheme = document.documentElement.getAttribute('data-theme')
-  const newTheme = currentTheme === 'synthwave' ? 'light' : 'synthwave'
+  const newTheme = currentTheme !== 'light' ? 'light' : 'synthwave'
   document.documentElement.setAttribute('data-theme', newTheme)
 }
 </script>


### PR DESCRIPTION
Because `document.documentElement.getAttribute('data-theme')` is uninitialized on the first theme switch, it will not properly switch to the other theme.

As a result, the value of `newTheme` on sequential switch clicks will be:

* (default) - `synthwave`
* `synthwave`
* `light`

Which means the first button click will appear not to do anything. Simply inverting the checks and negating it fixes that.