### PR TITLE
Add missing wasm-unsafe-eval to CSP

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -46,7 +46,7 @@ def create_app():
             "frame-ancestors": ["'self'"],
             "img-src": ["'self'", "data:", "t0.gstatic.com", "www.google.com"],
             "object-src": ["'none'"],
-            "script-src": ["'self'"],
+            "script-src": ["'self'", "'wasm-unsafe-eval'"],
             "script-src-attr": ["'none'"],
             "style-src": ["'self'", "https:", "'unsafe-inline'"],
             "upgrade-insecure-requests": [],


### PR DESCRIPTION
It seems that one of the frontend components is using wasm and it's unable to load because of CSP:

```txt
Uncaught CompileError: WebAssembly.instantiate(): Compiling or instantiating WebAssembly module violates the following Content Security policy directive because 'unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self'".
    at Module.E (wasm-CG6Dc4jp.js:1:622233)
    at index-Cc9iSXjX.js:1158:73085
    at async d (index-Cc9iSXjX.js:1158:68375)
    at async o4 (index-Cc9iSXjX.js:1158:68483)
    at async t (index-Cc9iSXjX.js:1158:72912)
    at async a_ (index-Cc9iSXjX.js:1158:73735)
    at async Promise.all (index 2)
    at async fN (index-Cc9iSXjX.js:1160:17412)
    at async gD (index-Cc9iSXjX.js:1169:2615)
    at async i (index-Cc9iSXjX.js:1169:3490)
E @ wasm-CG6Dc4jp.js:1
(anonymous) @ index-Cc9iSXjX.js:1158
await in (anonymous)
d @ index-Cc9iSXjX.js:1158
o4 @ index-Cc9iSXjX.js:1158
t @ index-Cc9iSXjX.js:1158
ed @ index-Cc9iSXjX.js:1158
a_ @ index-Cc9iSXjX.js:1158
...
```

I think it might cause the EML body not to render properly